### PR TITLE
Add config option to give maximum axis value to radar-chart

### DIFF
--- a/src/charts/radar.typ
+++ b/src/charts/radar.typ
@@ -9,6 +9,7 @@
 ///
 /// - data (dictionary): Dict with `labels` (axis names) and `series` (each with `name` and `values`)
 /// - size (length): Diameter of the radar chart
+// - axis-max-value (none, number): The maximum value of the chart’s axes
 /// - title (none, content): Optional chart title
 /// - show-legend (bool): Show series legend
 /// - show-value-labels (bool): Display scale values and data point labels
@@ -18,6 +19,7 @@
 #let radar-chart(
   data,
   size: 200pt,
+  axis-max-value: none,
   title: none,
   show-legend: true,
   show-value-labels: true,
@@ -34,7 +36,7 @@
 
   // Find max value across all series
   let all-values = series.map(s => s.values).flatten()
-  let max-val = calc.max(..all-values)
+  let max-val = if axis-max-value == none { calc.max(..all-values) } else { axis-max-value }
 
   // Respect both show-legend param and theme legend-position
   let show-legend = show-legend and t.legend-position != "none"

--- a/tests/test-radar.typ
+++ b/tests/test-radar.typ
@@ -8,3 +8,5 @@
 = Radar Chart
 
 #radar-chart(radar-data, title: "radar-chart")
+
+#radar-chart(radar-data, title: "radar-chart (scale-0-to-10)", axis-max-value: 10)


### PR DESCRIPTION
I really like the radar chart in your package—thanks for creating it!

For my assignments, I need to use radar charts with a fixed scale. Specifically, all axes must be rated from 1 to 10, even if some values don’t reach the maximum.

To support this, I added an option to set a predefined maximum value for the axis. In the example below, the first radar-chart is the 'default' radar chart, and the second radar-chart has a maximum axis value of '10':

<img width="728" height="1766" alt="image" src="https://github.com/user-attachments/assets/1ab8829a-051b-46c2-a294-32d29518b1f7" />
 