### PR TITLE
Fixed y-label alignment, rotated x-label alignment, added option for extra legend separation and auto computing space for x-labels

### DIFF
--- a/src/charts/area.typ
+++ b/src/charts/area.typ
@@ -3,7 +3,7 @@
 #import "../util.typ": normalize-data, nonzero, nice-ceil
 #import "../validate.typ": validate-simple-data, validate-series-data
 #import "../primitives/container.typ": chart-container
-#import "../primitives/axes.typ": cartesian-layout, draw-axis-lines, draw-grid, draw-axis-titles, draw-y-ticks, draw-x-even-labels, measure-y-tick-width
+#import "../primitives/axes.typ": cartesian-layout, draw-axis-lines, draw-grid, draw-axis-titles, draw-y-ticks, draw-x-even-labels, measure-y-tick-width, measure-x-tick-height
 #import "../primitives/legend.typ": draw-legend-auto
 #import "../primitives/layout.typ": resolve-size
 
@@ -21,6 +21,7 @@
 /// - x-label (none, content): X-axis title
 /// - y-label (none, content): Y-axis title
 /// - theme (none, dictionary): Theme overrides
+/// - extra-legend-separation (length): Extra space between legend and chart
 /// -> content
 #let area-chart(
   data,
@@ -37,6 +38,7 @@
   show-ticks: false,
   show-minor-grid: false,
   theme: none,
+  extra-legend-separation: 0pt
 ) = context {
   layout(size => {
   validate-simple-data(data, "area-chart")
@@ -54,7 +56,7 @@
 
   let cl = cartesian-layout(width, height, t)
 
-  chart-container(width, height, title, t, extra-height: 30pt)[
+  chart-container(width, height, title, t, extra-height: 30pt, extra-legend-separation: extra-legend-separation)[
     #let pad-top = cl.pad-top
     #let chart-height = cl.chart-height
     #let chart-width = cl.chart-width
@@ -134,7 +136,8 @@
 
       // Axis titles
       #let y-tw = measure-y-tick-width(min-val, max-val, t)
-      #draw-axis-titles(x-label, y-label, origin-x + chart-width / 2, pad-top + chart-height / 2, t, origin-x: origin-x, origin-y: origin-y, y-tick-width: y-tw)
+      #let x-th = measure-x-tick-height(labels, t, rotated: n>t.rotated-threshold)
+      #draw-axis-titles(x-label, y-label, origin-x + chart-width / 2, pad-top + chart-height / 2, t, origin-x: origin-x, origin-y: origin-y, y-tick-width: y-tw, x-tick-height: x-th)
     ]
   ]
   })
@@ -153,6 +156,7 @@
 /// - x-label (none, content): X-axis title
 /// - y-label (none, content): Y-axis title
 /// - theme (none, dictionary): Theme overrides
+/// - extra-legend-separation (length): Extra space between legend and chart
 /// -> content
 #let stacked-area-chart(
   data,
@@ -166,6 +170,7 @@
   x-label: none,
   y-label: none,
   theme: none,
+  extra-legend-separation: 0pt
 ) = context {
   layout(size => {
   validate-series-data(data, "stacked-area-chart")
@@ -193,7 +198,7 @@
   let cl = cartesian-layout(width, height, t)
 
   let legend-content = draw-legend-auto(series.map(s => s.name), t, show-legend: show-legend)
-  chart-container(width, height, title, t, extra-height: 50pt, legend: legend-content)[
+  chart-container(width, height, title, t, extra-height: 50pt, legend: legend-content, extra-legend-separation: extra-legend-separation)[
     #let pad-top = cl.pad-top
     #let chart-height = cl.chart-height
     #let chart-width = cl.chart-width
@@ -250,7 +255,8 @@
 
       // Axis titles
       #let y-tw = measure-y-tick-width(0, max-val, t, digits: 0)
-      #draw-axis-titles(x-label, y-label, origin-x + chart-width / 2, pad-top + chart-height / 2, t, origin-x: origin-x, origin-y: origin-y, y-tick-width: y-tw)
+      #let x-th = measure-x-tick-height(labels, t, rotated: n>t.rotated-threshold)
+      #draw-axis-titles(x-label, y-label, origin-x + chart-width / 2, pad-top + chart-height / 2, t, origin-x: origin-x, origin-y: origin-y, y-tick-width: y-tw, x-tick-height: x-th)
     ]
   ]
   })

--- a/src/charts/bar.typ
+++ b/src/charts/bar.typ
@@ -3,7 +3,7 @@
 #import "../util.typ": normalize-data, nonzero, nice-ceil
 #import "../validate.typ": validate-simple-data, validate-series-data, validate-grouped-stacked-data
 #import "../primitives/container.typ": chart-container
-#import "../primitives/axes.typ": cartesian-layout, draw-axis-lines, draw-grid, draw-axis-titles, draw-y-ticks, draw-x-ticks, draw-x-category-labels, draw-y-label, measure-y-tick-width
+#import "../primitives/axes.typ": cartesian-layout, draw-axis-lines, draw-grid, draw-axis-titles, draw-y-ticks, draw-x-ticks, draw-x-category-labels, draw-y-label, measure-y-tick-width, measure-x-tick-height
 #import "../primitives/legend.typ": draw-legend-auto
 #import "../primitives/annotations.typ": draw-annotations
 #import "../primitives/polar.typ": separator-stroke
@@ -20,6 +20,7 @@
 /// - x-label (none, content): X-axis title
 /// - y-label (none, content): Y-axis title
 /// - theme (none, dictionary): Theme overrides
+/// - extra-legend-separation (length): Extra space between legend and chart
 /// -> content
 #let horizontal-bar-chart(
   data,
@@ -31,6 +32,7 @@
   x-label: none,
   y-label: none,
   theme: none,
+  extra-legend-separation: 0pt
 ) = context {
   layout(size => {
   validate-simple-data(data, "horizontal-bar-chart")
@@ -45,7 +47,7 @@
 
   let cl = cartesian-layout(width, height, t, extra-left: t.axis-padding-left)
 
-  chart-container(width, height, title, t, extra-height: t.axis-padding-bottom)[
+  chart-container(width, height, title, t, extra-height: t.axis-padding-bottom, extra-legend-separation: extra-legend-separation)[
     #let pad-top = cl.pad-top
     #let chart-height = cl.chart-height
     #let chart-width = cl.chart-width
@@ -98,7 +100,9 @@
 
       // Axis titles
       #let y-tw = measure-y-tick-width(0, max-val, t)
-      #draw-axis-titles(x-label, y-label, origin-x + chart-width / 2, pad-top + chart-height / 2, t, origin-x: origin-x, origin-y: origin-y, y-tick-width: y-tw)
+      #let x-th = measure-x-tick-height(labels, t)
+
+      #draw-axis-titles(x-label, y-label, origin-x + chart-width / 2, pad-top + chart-height / 2, t, origin-x: origin-x, origin-y: origin-y, y-tick-width: y-tw, x-tick-height: x-th)
     ]
   ]
   })
@@ -116,6 +120,7 @@
 /// - y-label (none, content): Y-axis title
 /// - annotations (none, array): Optional annotation descriptors
 /// - theme (none, dictionary): Theme overrides
+/// - extra-legend-separation (length): Extra space between legend and chart
 /// -> content
 #let bar-chart(
   data,
@@ -132,6 +137,7 @@
   subtitle: none,
   radius: 0pt,
   theme: none,
+  extra-legend-separation: 0pt
 ) = context {
   layout(size => {
   validate-simple-data(data, "bar-chart")
@@ -146,7 +152,7 @@
 
   let cl = cartesian-layout(width, height, t)
 
-  chart-container(width, height, title, t, extra-height: t.axis-padding-bottom, subtitle: subtitle, radius: radius)[
+  chart-container(width, height, title, t, extra-height: t.axis-padding-bottom, subtitle: subtitle, radius: radius, extra-legend-separation: extra-legend-separation)[
     #let pad-top = cl.pad-top
     #let chart-height = cl.chart-height
     #let chart-width = cl.chart-width
@@ -198,7 +204,9 @@
 
       // Axis titles
       #let y-tw = measure-y-tick-width(0, max-val, t)
-      #draw-axis-titles(x-label, y-label, origin-x + chart-width / 2, pad-top + chart-height / 2, t, origin-x: origin-x, origin-y: origin-y, y-tick-width: y-tw)
+      #let x-th = measure-x-tick-height(labels, t, rotated: n>t.rotated-threshold)
+
+      #draw-axis-titles(x-label, y-label, origin-x + chart-width / 2, pad-top + chart-height / 2, t, origin-x: origin-x, origin-y: origin-y, y-tick-width: y-tw, x-tick-height: x-th)
 
       // Annotations
       #draw-annotations(annotations, origin-x, pad-top, chart-width, chart-height, -0.5, n - 0.5, 0, max-val, t)
@@ -217,6 +225,7 @@
 /// - x-label (none, content): X-axis title
 /// - y-label (none, content): Y-axis title
 /// - theme (none, dictionary): Theme overrides
+/// - extra-legend-separation (length): Extra space between legend and chart
 /// -> content
 #let grouped-bar-chart(
   data,
@@ -224,9 +233,10 @@
   height: auto,
   title: none,
   show-legend: true,
-  x-label: none,
+  x-label: "none",
   y-label: none,
   theme: none,
+  extra-legend-separation: 0pt
 ) = context {
   layout(size => {
   validate-series-data(data, "grouped-bar-chart")
@@ -243,7 +253,7 @@
   let cl = cartesian-layout(width, height, t)
 
   let legend-content = draw-legend-auto(series.map(s => s.name), t, show-legend: show-legend)
-  chart-container(width, height, title, t, extra-height: t.axis-padding-bottom + t.legend-gap, legend: legend-content)[
+  chart-container(width, height, title, t, extra-height: t.axis-padding-bottom + t.legend-gap, legend: legend-content, extra-legend-separation: extra-legend-separation)[
     #let pad-top = cl.pad-top
     #let chart-height = cl.chart-height
     #let chart-width = cl.chart-width
@@ -288,7 +298,8 @@
 
       // Axis titles
       #let y-tw = measure-y-tick-width(0, max-val, t)
-      #draw-axis-titles(x-label, y-label, origin-x + chart-width / 2, pad-top + chart-height / 2, t, origin-x: origin-x, origin-y: origin-y, y-tick-width: y-tw)
+      #let x-th = measure-x-tick-height(labels, t, rotated: labels.len()>t.rotated-threshold)
+      #draw-axis-titles(x-label, y-label, origin-x + chart-width / 2, pad-top + chart-height / 2, t, origin-x: origin-x, origin-y: origin-y, y-tick-width: y-tw, x-tick-height: x-th)
     ]
   ]
   })
@@ -304,6 +315,7 @@
 /// - x-label (none, content): X-axis title
 /// - y-label (none, content): Y-axis title
 /// - theme (none, dictionary): Theme overrides
+/// - extra-legend-separation (length): Extra space between legend and chart
 /// -> content
 #let stacked-bar-chart(
   data,
@@ -314,6 +326,7 @@
   x-label: none,
   y-label: none,
   theme: none,
+  extra-legend-separation: 0pt
 ) = context {
   layout(size => {
   validate-series-data(data, "stacked-bar-chart")
@@ -333,7 +346,7 @@
   let cl = cartesian-layout(width, height, t)
 
   let legend-content = draw-legend-auto(series.map(s => s.name), t, show-legend: show-legend)
-  chart-container(width, height, title, t, extra-height: t.axis-padding-bottom + t.legend-gap, legend: legend-content)[
+  chart-container(width, height, title, t, extra-height: t.axis-padding-bottom + t.legend-gap, legend: legend-content, extra-legend-separation: extra-legend-separation)[
     #let pad-top = cl.pad-top
     #let chart-height = cl.chart-height
     #let chart-width = cl.chart-width
@@ -382,7 +395,8 @@
 
       // Axis titles
       #let y-tw = measure-y-tick-width(0, max-val, t)
-      #draw-axis-titles(x-label, y-label, origin-x + chart-width / 2, pad-top + chart-height / 2, t, origin-x: origin-x, origin-y: origin-y, y-tick-width: y-tw)
+      #let x-th = measure-x-tick-height(labels, t, rotated: labels.len()>t.rotated-threshold)
+      #draw-axis-titles(x-label, y-label, origin-x + chart-width / 2, pad-top + chart-height / 2, t, origin-x: origin-x, origin-y: origin-y, y-tick-width: y-tw, x-tick-height: x-th)
     ]
   ]
   })
@@ -402,6 +416,7 @@
 /// - y-label (none, content): Y-axis title
 /// - annotations (none, array): Optional annotation descriptors
 /// - theme (none, dictionary): Theme overrides
+/// - extra-legend-separation (length): Extra space between legend and chart
 /// -> content
 #let grouped-stacked-bar-chart(
   data,
@@ -413,6 +428,7 @@
   y-label: none,
   annotations: none,
   theme: none,
+  extra-legend-separation: 0pt
 ) = context {
   layout(size => {
   validate-grouped-stacked-data(data, "grouped-stacked-bar-chart")
@@ -456,7 +472,7 @@
 
   // Legend shows segment names (consistent colors across groups)
   let legend-content = draw-legend-auto(segment-names, t, show-legend: show-legend)
-  chart-container(width, height, title, t, extra-height: t.axis-padding-bottom + t.legend-gap, legend: legend-content)[
+  chart-container(width, height, title, t, extra-height: t.axis-padding-bottom + t.legend-gap, legend: legend-content, extra-legend-separation: extra-legend-separation)[
     #let pad-top = cl.pad-top
     #let chart-height = cl.chart-height
     #let chart-width = cl.chart-width
@@ -514,7 +530,8 @@
 
       // Axis titles
       #let y-tw = measure-y-tick-width(0, max-val, t)
-      #draw-axis-titles(x-label, y-label, origin-x + chart-width / 2, pad-top + chart-height / 2, t, origin-x: origin-x, origin-y: origin-y, y-tick-width: y-tw)
+      #let x-th = measure-x-tick-height(labels, t, rotated: n-labels>t.rotated-threshold)
+      #draw-axis-titles(x-label, y-label, origin-x + chart-width / 2, pad-top + chart-height / 2, t, origin-x: origin-x, origin-y: origin-y, y-tick-width: y-tw, x-tick-height: x-th)
 
       // Annotations
       #draw-annotations(annotations, origin-x, pad-top, chart-width, chart-height, -0.5, n-labels - 0.5, 0, max-val, t)

--- a/src/charts/boxplot.typ
+++ b/src/charts/boxplot.typ
@@ -3,7 +3,7 @@
 #import "../util.typ": nonzero, nice-ceil
 #import "../validate.typ": validate-boxplot-data
 #import "../primitives/container.typ": chart-container
-#import "../primitives/axes.typ": cartesian-layout, draw-axis-lines, draw-y-ticks, draw-x-category-labels, draw-grid, draw-axis-titles, measure-y-tick-width
+#import "../primitives/axes.typ": cartesian-layout, draw-axis-lines, draw-y-ticks, draw-x-category-labels, draw-grid, draw-axis-titles, measure-y-tick-width, measure-x-tick-height
 #import "../primitives/layout.typ": resolve-size
 
 /// Renders a box-and-whisker plot for comparing distributions.
@@ -80,7 +80,8 @@
 
       // Axis titles
       #let y-tw = measure-y-tick-width(y-min, y-max, t, digits: 0)
-      #draw-axis-titles(x-label, y-label, origin-x + chart-width / 2, pad-top + chart-height / 2, t, origin-x: origin-x, origin-y: origin-y, y-tick-width: y-tw)
+      #let x-th = measure-x-tick-height(labels, t, rotated: n > t.rotated-threshold)
+      #draw-axis-titles(x-label, y-label, origin-x + chart-width / 2, pad-top + chart-height / 2, t, origin-x: origin-x, origin-y: origin-y, y-tick-width: y-tw, x-tick-height: x-th)
 
       // Draw each box
       #for (i, b) in boxes.enumerate() {

--- a/src/charts/bump.typ
+++ b/src/charts/bump.typ
@@ -23,6 +23,7 @@
 /// - show-labels (bool): Show series name labels at start and end of lines
 /// - show-legend (bool): Show series legend below the chart
 /// - theme (none, dictionary): Theme overrides
+/// - extra-legend-separation (length): Extra space between legend and chart
 /// -> content
 #let bump-chart(
   data,
@@ -34,6 +35,7 @@
   show-labels: true,
   show-legend: true,
   theme: none,
+  extra-legend-separation: 0pt
 ) = context {
   layout(size => {
   validate-series-data(data, "bump-chart")
@@ -56,7 +58,7 @@
   let cl = cartesian-layout(width, height, t)
 
   let legend-content = draw-legend-auto(series.map(s => s.name), t, show-legend: show-legend, swatch-type: "line")
-  chart-container(width, height, title, t, extra-height: 50pt, legend: legend-content)[
+  chart-container(width, height, title, t, extra-height: 50pt, legend: legend-content, extra-legend-separation: extra-legend-separation)[
     #let pad-top = cl.pad-top
     #let chart-height = cl.chart-height
     #let chart-width = cl.chart-width

--- a/src/charts/diverging.typ
+++ b/src/charts/diverging.typ
@@ -23,6 +23,7 @@
 /// - show-values (bool): Display value labels at bar ends
 /// - bar-height (auto, float): Bar thickness as fraction of slot (0 to 1), auto = 0.6
 /// - theme (none, dictionary): Theme overrides
+/// - extra-legend-separation (length): Extra space between legend and chart
 /// -> content
 #let diverging-bar-chart(
   data,
@@ -33,6 +34,7 @@
   bar-height: auto,
   x-label: none,
   theme: none,
+  extra-legend-separation: 0pt
 ) = context {
   layout(size => {
   validate-diverging-data(data, "diverging-bar-chart")
@@ -67,7 +69,7 @@
     ((name: left-label, color: get-color(t, 0)), (name: right-label, color: get-color(t, 1))),
     t, show-legend: show-legend,
   )
-  chart-container(width, height, title, t, extra-height: extra-h, legend: legend-content)[
+  chart-container(width, height, title, t, extra-height: extra-h, legend: legend-content, extra-legend-separation: extra-legend-separation)[
     #let chart-height = height - t.axis-padding-top - t.axis-padding-bottom - tick-area
     #let spacing = chart-height / n
     #let actual-bar-h = spacing * bar-frac

--- a/src/charts/dual-axis.typ
+++ b/src/charts/dual-axis.typ
@@ -22,6 +22,7 @@
   x-label: none,
   show-grid: auto,
   theme: none,
+  extra-legend-separation: 0pt
 ) = context {
   layout(size => {
   validate-dual-axis-data(data, "dual-axis-chart")
@@ -49,8 +50,12 @@
   let r-range = nonzero(r-max - r-min)
 
   let cl = cartesian-layout(width, height, t, extra-left: 10pt, extra-right: 10pt)
+  let legend-content = draw-legend-auto(
+      ((name: left-series.name, color: l-color), (name: right-series.name, color: r-color)),
+      t, swatch-type: "line",
+    )
 
-  chart-container(width, height, title, t, extra-height: 50pt)[
+  chart-container(width, height, title, t, extra-height: 50pt, legend: legend-content, extra-legend-separation: extra-legend-separation)[
     #let pad-top = cl.pad-top
     #let chart-height = cl.chart-height
     #let chart-width = cl.chart-width
@@ -168,11 +173,7 @@
       }
     ]
 
-    // Legend
-    #draw-legend-auto(
-      ((name: left-series.name, color: l-color), (name: right-series.name, color: r-color)),
-      t, swatch-type: "line",
-    )
+    
   ]
   })
 }

--- a/src/charts/dumbbell.typ
+++ b/src/charts/dumbbell.typ
@@ -22,6 +22,7 @@
 /// - line-width (length): Stroke width of connecting lines
 /// - show-values (bool): Display numeric values next to dots
 /// - theme (none, dictionary): Theme overrides
+/// - extra-legend-separation (length): Extra space between legend and chart
 /// -> content
 #let dumbbell-chart(
   data,
@@ -32,6 +33,7 @@
   line-width: 1.5pt,
   show-values: false,
   theme: none,
+  extra-legend-separation: 0pt
 ) = context {
   layout(size => {
   validate-dumbbell-data(data, "dumbbell-chart")
@@ -82,7 +84,7 @@
 
   let legend-content = draw-legend-auto(legend-entries, t, swatch-type: "circle")
 
-  chart-container(width, height, title, t, extra-height: 30pt, legend: legend-content)[
+  chart-container(width, height, title, t, extra-height: 30pt, legend: legend-content, extra-legend-separation: extra-legend-separation)[
     #box(width: width, height: height)[
       #let chart-height = height
       // Usable vertical space for rows — extra slot keeps last row off the axis

--- a/src/charts/gantt.typ
+++ b/src/charts/gantt.typ
@@ -21,6 +21,7 @@
 /// - show-grid (bool): Whether to draw vertical grid lines
 /// - today (none, int): Optional time index to draw a "today" marker line
 /// - theme (none, dictionary): Theme overrides
+/// - extra-legend-separation (length): Extra space between legend and chart
 /// -> content
 #let gantt-chart(
   data,
@@ -34,6 +35,7 @@
   show-legend: false,
   today: none,
   theme: none,
+  extra-legend-separation: 0pt
 ) = context {
   layout(size => {
   validate-gantt-data(data, "gantt-chart")
@@ -68,7 +70,16 @@
   let timeline-width = width - label-area - 10pt
   let col-width = timeline-width / time-count
 
-  chart-container(width, chart-height, title, t, extra-height: 30pt)[
+  // Group legend
+  let legend = none
+  if show-legend and has-groups {
+      legend = draw-legend(
+        group-names.enumerate().map(((i, g)) => (name: g, color: get-color(t, i))),
+        t,
+      )
+    }
+
+  chart-container(width, chart-height, title, t, extra-height: 30pt, legend: legend, extra-legend-separation: extra-legend-separation)[
     #let body-height = chart-height
 
     #box(width: width, height: body-height)[
@@ -91,7 +102,7 @@
 
       // Time labels along the bottom — below the axis line
       #let label-font = font-for-space(col-width, t.axis-label-size)
-      #let rotate-labels = time-count > 8
+      #let rotate-labels = time-count > t.rotated-threshold
       #let skip-n = density-skip(time-count, timeline-width, min-spacing: if rotate-labels { 18pt } else { 12pt })
       #let axis-y = body-height - 20pt
       #let label-y = axis-y + 4pt  // below the axis line
@@ -192,13 +203,6 @@
       }
     ]
 
-    // Group legend
-    #if show-legend and has-groups {
-      draw-legend(
-        group-names.enumerate().map(((i, g)) => (name: g, color: get-color(t, i))),
-        t,
-      )
-    }
   ]
   })
 }

--- a/src/charts/histogram.typ
+++ b/src/charts/histogram.typ
@@ -3,7 +3,7 @@
 #import "../util.typ": nonzero, nice-ceil
 #import "../validate.typ": validate-histogram-data
 #import "../primitives/container.typ": chart-container
-#import "../primitives/axes.typ": cartesian-layout, draw-axis-lines, draw-grid, draw-y-ticks, draw-x-ticks, draw-axis-titles, measure-y-tick-width
+#import "../primitives/axes.typ": cartesian-layout, draw-axis-lines, draw-grid, draw-y-ticks, draw-x-ticks, draw-axis-titles, measure-y-tick-width, measure-x-tick-height
 #import "../primitives/layout.typ": resolve-size
 
 /// Renders a histogram showing the frequency distribution of numeric data.
@@ -150,7 +150,8 @@
 
       // Axis titles
       #let y-tw = measure-y-tick-width(0, y-max, t, digits: if density { 3 } else { 1 })
-      #draw-axis-titles(x-label, y-label, origin-x + chart-width / 2, pad-top + chart-height / 2, t, origin-x: origin-x, origin-y: origin-y, y-tick-width: y-tw)
+      #let x-th = measure-x-tick-height(([#data-max],), t)
+      #draw-axis-titles(x-label, y-label, origin-x + chart-width / 2, pad-top + chart-height / 2, t, origin-x: origin-x, origin-y: origin-y, y-tick-width: y-tw, x-tick-height: x-th)
     ]
   ]
   })

--- a/src/charts/line.typ
+++ b/src/charts/line.typ
@@ -3,7 +3,7 @@
 #import "../util.typ": normalize-data, nonzero, nice-ceil, nice-floor
 #import "../validate.typ": validate-simple-data, validate-series-data
 #import "../primitives/container.typ": chart-container
-#import "../primitives/axes.typ": cartesian-layout, draw-axis-lines, draw-grid, draw-axis-titles, draw-y-ticks, draw-x-category-labels, draw-x-even-labels, measure-y-tick-width
+#import "../primitives/axes.typ": cartesian-layout, draw-axis-lines, draw-grid, draw-axis-titles, draw-y-ticks, draw-x-category-labels, draw-x-even-labels, measure-y-tick-width, measure-x-tick-height
 #import "../primitives/legend.typ": draw-legend-auto
 #import "../primitives/annotations.typ": draw-annotations
 #import "../primitives/layout.typ": resolve-size
@@ -23,6 +23,7 @@
 /// - y-label (none, content): Y-axis title
 /// - annotations (none, array): Optional annotation descriptors
 /// - theme (none, dictionary): Theme overrides
+/// - extra-legend-separation (length): Extra space between legend and chart
 /// -> content
 #let line-chart(
   data,
@@ -42,6 +43,7 @@
   subtitle: none,
   radius: 0pt,
   theme: none,
+  extra-legend-separation: 0pt
 ) = context {
   layout(size => {
   validate-simple-data(data, "line-chart")
@@ -59,7 +61,7 @@
 
   let cl = cartesian-layout(width, height, t)
 
-  chart-container(width, height, title, t, extra-height: 30pt, subtitle: subtitle, radius: radius)[
+  chart-container(width, height, title, t, extra-height: 30pt, subtitle: subtitle, radius: radius, extra-legend-separation: extra-legend-separation)[
     #let pad-top = cl.pad-top
     #let chart-height = cl.chart-height
     #let chart-width = cl.chart-width
@@ -124,7 +126,8 @@
 
       // Axis titles
       #let y-tw = measure-y-tick-width(min-val, max-val, t)
-      #draw-axis-titles(x-label, y-label, origin-x + chart-width / 2, pad-top + chart-height / 2, t, origin-x: origin-x, origin-y: origin-y, y-tick-width: y-tw)
+      #let x-th = measure-x-tick-height(labels, t, rotated: n>t.rotated-threshold)
+      #draw-axis-titles(x-label, y-label, origin-x + chart-width / 2, pad-top + chart-height / 2, t, origin-x: origin-x, origin-y: origin-y, y-tick-width: y-tw, x-tick-height: x-th)
 
       // Annotations
       #draw-annotations(annotations, origin-x, pad-top, chart-width, chart-height, 0, calc.max(n - 1, 1), min-val, max-val, t)
@@ -144,6 +147,7 @@
 /// - x-label (none, content): X-axis title
 /// - y-label (none, content): Y-axis title
 /// - theme (none, dictionary): Theme overrides
+/// - extra-legend-separation (length): Extra space between legend and chart
 /// -> content
 #let multi-line-chart(
   data,
@@ -157,6 +161,7 @@
   x-label: none,
   y-label: none,
   theme: none,
+  extra-legend-separation: 0pt
 ) = context {
   layout(size => {
   validate-series-data(data, "multi-line-chart")
@@ -175,7 +180,7 @@
   let cl = cartesian-layout(width, height, t)
 
   let legend-content = draw-legend-auto(series.map(s => s.name), t, show-legend: show-legend, swatch-type: "line")
-  chart-container(width, height, title, t, extra-height: 50pt, legend: legend-content)[
+  chart-container(width, height, title, t, extra-height: 50pt, legend: legend-content, extra-legend-separation: extra-legend-separation)[
     #let pad-top = cl.pad-top
     #let chart-height = cl.chart-height
     #let chart-width = cl.chart-width
@@ -233,7 +238,9 @@
 
       // Axis titles
       #let y-tw = measure-y-tick-width(min-val, max-val, t)
-      #draw-axis-titles(x-label, y-label, origin-x + chart-width / 2, pad-top + chart-height / 2, t, origin-x: origin-x, origin-y: origin-y, y-tick-width: y-tw)
+      #let x-th = measure-x-tick-height(labels, t, rotated: n>t.rotated-threshold)
+      
+      #draw-axis-titles(x-label, y-label, origin-x + chart-width / 2, pad-top + chart-height / 2, t, origin-x: origin-x, origin-y: origin-y, y-tick-width: y-tw, x-tick-height: x-th)
     ]
   ]
   })

--- a/src/charts/lollipop.typ
+++ b/src/charts/lollipop.typ
@@ -3,7 +3,7 @@
 #import "../util.typ": normalize-data, nonzero, nice-ceil
 #import "../validate.typ": validate-simple-data
 #import "../primitives/container.typ": chart-container
-#import "../primitives/axes.typ": cartesian-layout, draw-axis-lines, draw-grid, draw-axis-titles, draw-y-ticks, draw-x-ticks, draw-x-category-labels, draw-y-label, measure-y-tick-width
+#import "../primitives/axes.typ": cartesian-layout, draw-axis-lines, draw-grid, draw-axis-titles, draw-y-ticks, draw-x-ticks, draw-x-category-labels, draw-y-label, measure-y-tick-width, measure-x-tick-height
 #import "../primitives/annotations.typ": draw-annotations
 #import "../primitives/layout.typ": resolve-size
 
@@ -116,7 +116,8 @@
 
       // Axis titles
       #let y-tw = measure-y-tick-width(0, max-val, t)
-      #draw-axis-titles(x-label, y-label, origin-x + chart-width / 2, pad-top + chart-height / 2, t, origin-x: origin-x, origin-y: origin-y, y-tick-width: y-tw)
+      #let x-th = measure-x-tick-height(labels, t, rotated: n > t.rotated-threshold)
+      #draw-axis-titles(x-label, y-label, origin-x + chart-width / 2, pad-top + chart-height / 2, t, origin-x: origin-x, origin-y: origin-y, y-tick-width: y-tw, x-tick-height: x-th)
 
       // Annotations
       #draw-annotations(annotations, origin-x, pad-top, chart-width, chart-height, -0.5, n - 0.5, 0, max-val, t)
@@ -230,7 +231,8 @@
 
       // Axis titles
       #let y-tw = measure-y-tick-width(0, max-val, t)
-      #draw-axis-titles(x-label, y-label, origin-x + chart-width / 2, pad-top + chart-height / 2, t, origin-x: origin-x, origin-y: origin-y, y-tick-width: y-tw)
+      #let x-th = measure-x-tick-height(([#max-val],), t, rotated: n > t.rotated-threshold)
+      #draw-axis-titles(x-label, y-label, origin-x + chart-width / 2, pad-top + chart-height / 2, t, origin-x: origin-x, origin-y: origin-y, y-tick-width: y-tw, x-tick-height: x-th)
     ]
   ]
   })

--- a/src/charts/radar.typ
+++ b/src/charts/radar.typ
@@ -14,6 +14,7 @@
 /// - show-value-labels (bool): Display scale values and data point labels
 /// - fill-opacity (ratio): Opacity of the filled data area
 /// - theme (none, dictionary): Theme overrides
+/// - extra-legend-separation (length): Extra space between legend and chart
 /// -> content
 #let radar-chart(
   data,
@@ -23,6 +24,7 @@
   show-value-labels: true,
   fill-opacity: 15%,
   theme: none,
+  extra-legend-separation: 0pt
 ) = context {
   layout(avail => {
   validate-series-data(data, "radar-chart")
@@ -72,7 +74,7 @@
     d
   } else { t }
 
-  align(center, chart-container(size, size, title, t-with-legend, extra-height: 40pt, legend: legend-content, legend-width: legend-width)[
+  align(center, chart-container(size, size, title, t-with-legend, extra-height: 40pt, legend: legend-content, legend-width: legend-width, extra-legend-separation: extra-legend-separation)[
     #box(width: size, height: size)[
         // Draw grid polygons with value labels
         #for level in array.range(1, 5) {

--- a/src/charts/scatter.typ
+++ b/src/charts/scatter.typ
@@ -4,7 +4,7 @@
 #import "../primitives/layout.typ": label-fits-inside, place-cartesian-label, try-fit-label, greedy-deconflict, resolve-size
 #import "../validate.typ": validate-scatter-data, validate-multi-scatter-data, validate-bubble-data, validate-multi-bubble-data
 #import "../primitives/container.typ": chart-container
-#import "../primitives/axes.typ": cartesian-layout, draw-axis-lines, draw-grid, draw-axis-titles, draw-y-ticks, draw-x-ticks, measure-y-tick-width
+#import "../primitives/axes.typ": cartesian-layout, draw-axis-lines, draw-grid, draw-axis-titles, draw-y-ticks, draw-x-ticks, measure-y-tick-width, measure-x-tick-height
 #import "../primitives/legend.typ": draw-legend-auto, draw-size-legend
 #import "../primitives/annotations.typ": draw-annotations
 
@@ -101,7 +101,8 @@
 
       // Axis titles
       #let y-tw = measure-y-tick-width(y-min, y-max, t)
-      #draw-axis-titles(x-label, y-label, origin-x + chart-width / 2, pad-top + chart-height / 2, t, origin-x: origin-x, origin-y: origin-y, y-tick-width: y-tw)
+      #let x-th = measure-x-tick-height(([#x-max],), t)
+      #draw-axis-titles(x-label, y-label, origin-x + chart-width / 2, pad-top + chart-height / 2, t, origin-x: origin-x, origin-y: origin-y, y-tick-width: y-tw, x-tick-height: x-th)
 
       // Annotations
       #draw-annotations(annotations, origin-x, pad-top, chart-width, chart-height, x-min, x-max, y-min, y-max, t)
@@ -122,6 +123,7 @@
 /// - show-grid (auto, bool): Draw background grid lines; `auto` uses theme default
 /// - show-legend (bool): Show series legend
 /// - theme (none, dictionary): Theme overrides
+/// - extra-legend-separation (length): Extra space between legend and chart
 /// -> content
 #let multi-scatter-plot(
   data,
@@ -133,6 +135,7 @@
   point-size: 5pt,
   show-grid: auto,
   show-legend: true,
+  extra-legend-separation: 0pt,
   theme: none,
 ) = context {
   layout(size => {
@@ -160,7 +163,7 @@
   let cl = cartesian-layout(width, height, t, extra-left: 10pt)
 
   let legend-content = draw-legend-auto(series.map(s => s.name), t, show-legend: show-legend, swatch-type: "circle")
-  chart-container(width, height, title, t, extra-height: 50pt, legend: legend-content)[
+  chart-container(width, height, title, t, extra-height: 50pt, legend: legend-content, extra-legend-separation: extra-legend-separation)[
     #let pad-top = cl.pad-top
     #let chart-height = cl.chart-height
     #let chart-width = cl.chart-width
@@ -200,7 +203,8 @@
       }
 
       #let y-tw = measure-y-tick-width(y-min, y-max, t)
-      #draw-axis-titles(x-label, y-label, origin-x + chart-width / 2, pad-top + chart-height / 2, t, origin-x: origin-x, origin-y: origin-y, y-tick-width: y-tw)
+      #let x-th = measure-x-tick-height(([#x-max],), t)
+      #draw-axis-titles(x-label, y-label, origin-x + chart-width / 2, pad-top + chart-height / 2, t, origin-x: origin-x, origin-y: origin-y, y-tick-width: y-tw, x-tick-height: x-th)
     ]
   ]
   })
@@ -405,7 +409,8 @@
 
       // Axis titles
       #let y-tw = measure-y-tick-width(y-min, y-max, t)
-      #draw-axis-titles(x-label, y-label, origin-x + chart-width / 2, pad-top + chart-height / 2, t, origin-x: origin-x, origin-y: origin-y, y-tick-width: y-tw)
+      #let x-th = measure-x-tick-height(([#x-max],), t)
+      #draw-axis-titles(x-label, y-label, origin-x + chart-width / 2, pad-top + chart-height / 2, t, origin-x: origin-x, origin-y: origin-y, y-tick-width: y-tw, x-tick-height: x-th)
     ]
 
     // Size legend below chart

--- a/src/charts/waffle.typ
+++ b/src/charts/waffle.typ
@@ -23,6 +23,7 @@
 /// - show-legend (bool): Display legend with category names and colors
 /// - show-values (bool): Display percentage labels in the legend
 /// - theme (none, dictionary): Theme overrides
+/// - extra-legend-separation (length): Extra space between legend and chart
 /// -> content
 #let waffle-chart(
   data,
@@ -35,6 +36,7 @@
   show-legend: true,
   show-values: true,
   theme: none,
+  extra-legend-separation: 0pt,
 ) = context {
   layout(avail => {
   validate-simple-data(data, "waffle-chart")
@@ -110,7 +112,7 @@
   let wt = (..t, legend-position: "right")
   let legend-content = draw-legend-auto(legend-entries, wt, show-legend: show-legend)
 
-  align(center, chart-container(size, grid-height, title, wt, legend: legend-content)[
+  align(center, chart-container(size, grid-height, title, wt, legend: legend-content, extra-legend-separation: extra-legend-separation)[
     // Draw grid bottom-to-top, left-to-right
     #box(width: size, height: grid-height)[
       #align(center + top)[

--- a/src/charts/waterfall.typ
+++ b/src/charts/waterfall.typ
@@ -3,7 +3,7 @@
 #import "../util.typ": normalize-data, format-number, nonzero, nice-ceil
 #import "../validate.typ": validate-simple-data
 #import "../primitives/container.typ": chart-container
-#import "../primitives/axes.typ": cartesian-layout, draw-axis-lines, draw-grid, draw-axis-titles, draw-y-ticks, draw-x-category-labels, measure-y-tick-width
+#import "../primitives/axes.typ": cartesian-layout, draw-axis-lines, draw-grid, draw-axis-titles, draw-y-ticks, draw-x-category-labels, measure-y-tick-width, measure-x-tick-height
 #import "../primitives/legend.typ": draw-legend
 #import "../primitives/layout.typ": resolve-size
 
@@ -22,6 +22,7 @@
 /// - x-label (none, content): X-axis title
 /// - y-label (none, content): Y-axis title
 /// - theme (none, dictionary): Theme overrides
+/// - extra-legend-separation (length): Extra space between legend and chart
 /// -> content
 #let waterfall-chart(
   data,
@@ -38,6 +39,7 @@
   x-label: none,
   y-label: none,
   theme: none,
+  extra-legend-separation: 0pt
 ) = context {
   layout(size => {
   validate-simple-data(data, "waterfall-chart")
@@ -113,7 +115,16 @@
   // Category labels + axis title fit within axis-padding-bottom
   let extra-h = if show-legend { t.legend-size + t.legend-gap + t.legend-swatch-size } else { 0pt }
 
-  chart-container(width, height, title, t, extra-height: extra-h)[
+  // Color key legend
+  let legend = none
+  if show-legend {
+     legend = draw-legend(
+      ((name: "Increase", color: pos-color), (name: "Decrease", color: neg-color), (name: "Total", color: tot-color)),
+      t,
+    )
+  }
+
+  chart-container(width, height, title, t, extra-height: extra-h, legend: legend, extra-legend-separation: extra-legend-separation)[
     #let pad-top = cl.pad-top
     #let chart-height = cl.chart-height
     #let chart-width = cl.chart-width
@@ -207,16 +218,11 @@
 
       // Axis titles
       #let y-tw = measure-y-tick-width(y-min, y-max, t, digits: 0)
-      #draw-axis-titles(x-label, y-label, origin-x + chart-width / 2, pad-top + chart-height / 2, t, origin-x: origin-x, origin-y: origin-y, y-tick-width: y-tw)
+      #let x-th = measure-x-tick-height(labels, t, rotated: n>t.rotated-threshold)
+      #draw-axis-titles(x-label, y-label, origin-x + chart-width / 2, pad-top + chart-height / 2, t, origin-x: origin-x, origin-y: origin-y, y-tick-width: y-tw, x-tick-height: x-th)
     ]
 
-    // Color key legend
-    #if show-legend {
-      draw-legend(
-        ((name: "Increase", color: pos-color), (name: "Decrease", color: neg-color), (name: "Total", color: tot-color)),
-        t,
-      )
-    }
+
   ]
   })
 }

--- a/src/primitives/axes.typ
+++ b/src/primitives/axes.typ
@@ -14,7 +14,7 @@
 /// - extra-left (length): Additional left padding beyond theme default
 /// - extra-right (length): Additional right padding beyond theme default
 /// -> dictionary
-#let cartesian-layout(width, height, theme, extra-left: 0pt, extra-right: 0pt) = {
+#let cartesian-layout(width, height, theme, extra-left: 0pt, extra-right: 10pt) = {
   let pad-left = theme.axis-padding-left + extra-left
   let pad-right = theme.axis-padding-right + extra-right
   let pad-top = theme.axis-padding-top
@@ -39,13 +39,9 @@
   let chart-width = x-end - origin-x
   let chart-height = origin-y - y-start
   // Y-axis: vertical from y-start down to origin-y at x=origin-x
-  place(left + top,
-    line(start: (origin-x, y-start), end: (origin-x, origin-y), stroke: theme.axis-stroke)
-  )
+  place(left + top, line(start: (origin-x, y-start), end: (origin-x, origin-y), stroke: theme.axis-stroke))
   // X-axis: horizontal from origin-x to x-end at y=origin-y
-  place(left + top,
-    line(start: (origin-x, origin-y), end: (x-end, origin-y), stroke: theme.axis-stroke)
-  )
+  place(left + top, line(start: (origin-x, origin-y), end: (x-end, origin-y), stroke: theme.axis-stroke))
   // Tick marks
   if show-ticks {
     let tick-count = theme.tick-count
@@ -54,12 +50,10 @@
       let fraction = if tick-count > 1 { i / (tick-count - 1) } else { 0 }
       // Y-axis ticks (left side)
       let y = y-start + chart-height - fraction * chart-height
-      place(left + top,
-        line(start: (origin-x - tick-len, y), end: (origin-x, y), stroke: theme.axis-stroke))
+      place(left + top, line(start: (origin-x - tick-len, y), end: (origin-x, y), stroke: theme.axis-stroke))
       // X-axis ticks (bottom)
       let x = origin-x + fraction * chart-width
-      place(left + top,
-        line(start: (x, origin-y), end: (x, origin-y + tick-len), stroke: theme.axis-stroke))
+      place(left + top, line(start: (x, origin-y), end: (x, origin-y + tick-len), stroke: theme.axis-stroke))
     }
   }
 }
@@ -79,13 +73,15 @@
     let label = format-number(value, digits: digits, mode: theme.number-format)
     let gap = theme.axis-label-gap
     if side == "right" {
-      place(left + top, dx: x-pos + gap, dy: y,
-        move(dy: -0.5em, text(size: theme.axis-label-size, fill: fill-color)[#label]))
+      place(left + top, dx: x-pos + gap, dy: y, box(height: 0pt, align(left + horizon, text(
+        size: theme.axis-label-size,
+        fill: fill-color,
+      )[#label])))
     } else {
-      place(left + top, dx: 0pt, dy: y,
-        box(width: x-pos - gap / 2, height: 0pt,
-          align(right, move(dy: -0.5em,
-            text(size: theme.axis-label-size, fill: fill-color)[#label]))))
+      place(left + top, dx: 0pt, dy: y, box(width: x-pos - gap / 2, height: 0pt, align(right + horizon, text(
+        size: theme.axis-label-size,
+        fill: fill-color,
+      )[#label])))
     }
   }
 }
@@ -101,16 +97,15 @@
     if calc.rem(i, skip) != 0 and i != n - 1 { continue }
     let x = x-start + i * spacing + center-offset
     if rotate-labels {
-      place(left + top, dx: x + spacing / 2, dy: y-pos,
-        rotate(-45deg, origin: top + right,
-          text(size: theme.axis-label-size, fill: theme.text-color)[#labels.at(i)]
-        )
-      )
+      place(left + top, dx: x, dy: y-pos, rotate(-45deg, origin: right, box(width: spacing/2, align(
+        right,
+        text(size: theme.axis-label-size, fill: theme.text-color)[#labels.at(i)],
+      ))))
     } else {
-      place(left + top, dx: x, dy: y-pos,
-        box(width: spacing, height: theme.axis-label-size * 2,
-          align(center + top, text(size: theme.axis-label-size, fill: theme.text-color)[#labels.at(i)]))
-      )
+      place(left + top, dx: x, dy: y-pos, box(width: spacing, height: theme.axis-label-size * 2, align(
+        center + top,
+        text(size: theme.axis-label-size, fill: theme.text-color)[#labels.at(i)],
+      )))
     }
   }
 }
@@ -125,10 +120,14 @@
     let value = min-val + val-range * fraction
     let x = x-offset + fraction * chart-width
     let label-w = theme.axis-label-size * 4
-    place(left + top, dx: x - label-w / 2, dy: y-pos,
-      box(width: label-w, height: theme.axis-label-size * 2,
-        align(center + top, text(size: theme.axis-label-size, fill: theme.text-color)[#format-number(value, digits: digits, mode: theme.number-format)]))
-    )
+    place(left + top, dx: x - label-w / 2, dy: y-pos, box(width: label-w, height: theme.axis-label-size * 2, align(
+      center + top,
+      text(size: theme.axis-label-size, fill: theme.text-color)[#format-number(
+        value,
+        digits: digits,
+        mode: theme.number-format,
+      )],
+    )))
   }
 }
 
@@ -137,19 +136,21 @@
   let x-spacing = if n > 1 { chart-width / (n - 1) } else { chart-width }
   for (i, lbl) in labels.enumerate() {
     let x = if n == 1 { origin-x } else { origin-x + (i / (n - 1)) * chart-width }
-    place(left + top, dx: x - x-spacing / 2, dy: origin-y + theme.axis-label-gap,
-      box(width: x-spacing, height: theme.axis-label-size * 2,
-        align(center + top, text(size: theme.axis-label-size, fill: theme.text-color)[#lbl])))
+    place(left + top, dx: x - x-spacing / 2, dy: origin-y + theme.axis-label-gap, box(
+      width: x-spacing,
+      height: theme.axis-label-size * 2,
+      align(center + top, text(size: theme.axis-label-size, fill: theme.text-color)[#lbl]),
+    ))
   }
 }
 
 // Draw a single right-aligned y-axis category label in the left margin.
 // Used by horizontal charts (horizontal-bar, horizontal-lollipop, dumbbell, diverging).
 #let draw-y-label(label, y, margin-width, theme) = {
-  place(left + top, dx: 0pt, dy: y,
-    box(width: margin-width - theme.axis-label-gap, height: 0pt,
-      align(right, move(dy: -0.5em,
-        text(size: theme.axis-label-size, fill: theme.text-color)[#label]))))
+  place(left + top, dx: 0pt, dy: y, box(width: margin-width - theme.axis-label-gap, height: 0pt, align(right, move(
+    dy: -0.5em,
+    text(size: theme.axis-label-size, fill: theme.text-color)[#label],
+  ))))
 }
 
 // Draw grid lines behind chart area.
@@ -166,12 +167,10 @@
         let fraction = (i + j / minor-count) / (tick-count - 1)
         // Horizontal minor
         let y = y-start + chart-height - fraction * chart-height
-        place(left + top,
-          line(start: (x-start, y), end: (x-start + chart-width, y), stroke: minor-stroke))
+        place(left + top, line(start: (x-start, y), end: (x-start + chart-width, y), stroke: minor-stroke))
         // Vertical minor
         let x = x-start + fraction * chart-width
-        place(left + top,
-          line(start: (x, y-start), end: (x, y-start + chart-height), stroke: minor-stroke))
+        place(left + top, line(start: (x, y-start), end: (x, y-start + chart-height), stroke: minor-stroke))
       }
     }
   }
@@ -180,16 +179,12 @@
   for i in array.range(tick-count) {
     let fraction = if tick-count > 1 { i / (tick-count - 1) } else { 0 }
     let y = y-start + chart-height - fraction * chart-height
-    place(left + top,
-      line(start: (x-start, y), end: (x-start + chart-width, y), stroke: theme.grid-stroke)
-    )
+    place(left + top, line(start: (x-start, y), end: (x-start + chart-width, y), stroke: theme.grid-stroke))
   }
   for i in array.range(tick-count) {
     let fraction = if tick-count > 1 { i / (tick-count - 1) } else { 0 }
     let x = x-start + fraction * chart-width
-    place(left + top,
-      line(start: (x, y-start), end: (x, y-start + chart-height), stroke: theme.grid-stroke)
-    )
+    place(left + top, line(start: (x, y-start), end: (x, y-start + chart-height), stroke: theme.grid-stroke))
   }
 }
 
@@ -222,8 +217,17 @@
 //
 // y-tick-width: measured width of the widest y-tick label (from measure-y-tick-width)
 // x-tick-height: measured height of x-tick labels (defaults to axis-label-size * 2)
-#let draw-axis-titles(x-label, y-label, x-center, y-center, theme,
-  origin-x: none, origin-y: none, y-tick-width: 0pt, x-tick-height: none) = {
+#let draw-axis-titles(
+  x-label,
+  y-label,
+  x-center,
+  y-center,
+  theme,
+  origin-x: none,
+  origin-y: none,
+  y-tick-width: 0pt,
+  x-tick-height: none,
+) = {
   let ax-origin-y = if origin-y != none { origin-y } else { y-center * 2 }
   let ax-origin-x = if origin-x != none { origin-x } else { theme.axis-padding-left }
   let gap = theme.axis-label-gap
@@ -237,9 +241,7 @@
       measure(text(size: theme.axis-label-size)[0]).height * 1.4
     }
     let x-title-dy = ax-origin-y + gap + tick-h + gap / 2
-    place(left + top, dx: x-center, dy: x-title-dy,
-      move(dx: -box-w / 2, box(width: box-w, align(center, lbl-content)))
-    )
+    place(left + top, dx: x-center, dy: x-title-dy, move(dx: -box-w / 2, box(width: box-w, align(center, lbl-content))))
   }
   if y-label != none {
     let lbl-content = text(size: theme.axis-title-size, fill: theme.text-color)[#y-label]
@@ -249,8 +251,6 @@
     // Tight offset (gap/6) keeps title close without overlapping
     let y-title-dx = ax-origin-x - gap / 6 - y-tick-width - rot-size.width
 
-    place(left + top, dx: y-title-dx, dy: y-center - rot-size.height / 2,
-      rotated
-    )
+    place(left + top, dx: y-title-dx, dy: y-center - rot-size.height / 2, rotated)
   }
 }

--- a/src/primitives/axes.typ
+++ b/src/primitives/axes.typ
@@ -90,14 +90,14 @@
 // Labels are centered under their position using the spacing width.
 #let draw-x-category-labels(labels, x-start, spacing, y-pos, theme, center-offset: 0pt) = {
   let n = labels.len()
-  let rotate-labels = n > 8
+  let rotate-labels = n > theme.rotated-threshold
   let skip = density-skip(n, spacing * n)
 
   for i in array.range(n) {
     if calc.rem(i, skip) != 0 and i != n - 1 { continue }
     let x = x-start + i * spacing + center-offset
     if rotate-labels {
-      place(left + top, dx: x, dy: y-pos, rotate(-45deg, origin: right, box(width: spacing/2, align(
+      place(left + top, dx: x, dy: y-pos, rotate(-45deg, origin: right, box(width: spacing / 2, align(
         right,
         text(size: theme.axis-label-size, fill: theme.text-color)[#labels.at(i)],
       ))))
@@ -134,13 +134,24 @@
 // Draw evenly-spaced x-axis labels (for line/area/bump charts where points are spread uniformly).
 #let draw-x-even-labels(labels, n, origin-x, chart-width, origin-y, theme) = {
   let x-spacing = if n > 1 { chart-width / (n - 1) } else { chart-width }
+  let rotate-labels = n > theme.rotated-threshold
   for (i, lbl) in labels.enumerate() {
     let x = if n == 1 { origin-x } else { origin-x + (i / (n - 1)) * chart-width }
-    place(left + top, dx: x - x-spacing / 2, dy: origin-y + theme.axis-label-gap, box(
-      width: x-spacing,
-      height: theme.axis-label-size * 2,
-      align(center + top, text(size: theme.axis-label-size, fill: theme.text-color)[#lbl]),
-    ))
+    if rotate-labels {
+      place(left + top, dx: x - x-spacing / 2, dy: origin-y + theme.axis-label-gap, rotate(-45deg, origin: right, box(
+        width: x-spacing / 2,
+        align(
+          right,
+          text(size: theme.axis-label-size, fill: theme.text-color)[#lbl],
+        ),
+      )))
+    } else {
+      place(left + top, dx: x - x-spacing / 2, dy: origin-y + theme.axis-label-gap, box(
+        width: x-spacing,
+        height: theme.axis-label-size * 2,
+        align(center + top, text(size: theme.axis-label-size, fill: theme.text-color)[#lbl]),
+      ))
+    }
   }
 }
 
@@ -209,6 +220,24 @@
   max-w
 }
 
+#let measure-x-tick-height(values, theme, digits: 1, rotated: false) = {
+  let max-h = 0pt
+  if not rotated {
+    max-h = measure(text(size: theme.axis-label-size)[0]).height
+  } else {
+    for value in values {
+      if type(value) == float {
+        value = format-number(value, digits: digits, mode: theme.number-format)
+      }
+      let w = measure(text(size: theme.axis-label-size)[#value]).width
+      // When rotated, it is assumed that it is rotated by 45 degrees, so the effective height is the diagonal of the label box
+      let h = w * calc.sqrt(2) / 2
+      if h > max-h { max-h = h }
+    }
+  }
+  max-h
+}
+
 // Draw axis title labels (x below axis, y rotated on left).
 //
 // Layout is measurement-based:
@@ -226,7 +255,7 @@
   origin-x: none,
   origin-y: none,
   y-tick-width: 0pt,
-  x-tick-height: none,
+  x-tick-height: 0pt,
 ) = {
   let ax-origin-y = if origin-y != none { origin-y } else { y-center * 2 }
   let ax-origin-x = if origin-x != none { origin-x } else { theme.axis-padding-left }
@@ -237,10 +266,7 @@
     let lbl-size = measure(lbl-content)
     let box-w = lbl-size.width + theme.axis-title-size
     // Position below x-tick labels: measure actual tick label height + small gap
-    let tick-h = if x-tick-height != none { x-tick-height } else {
-      measure(text(size: theme.axis-label-size)[0]).height * 1.4
-    }
-    let x-title-dy = ax-origin-y + gap + tick-h + gap / 2
+    let x-title-dy = ax-origin-y + gap  + gap / 2 + x-tick-height * 1.4
     place(left + top, dx: x-center, dy: x-title-dy, move(dx: -box-w / 2, box(width: box-w, align(center, lbl-content))))
   }
   if y-label != none {

--- a/src/primitives/axes.typ
+++ b/src/primitives/axes.typ
@@ -240,7 +240,6 @@
   }
   max-h
 }
-
 // Draw axis title labels (x below axis, y rotated on left).
 //
 // Layout is measurement-based:
@@ -268,10 +267,10 @@
     let lbl-content = text(size: theme.axis-title-size, fill: theme.text-color)[#x-label]
     let lbl-size = measure(lbl-content)
     // Position below x-tick labels: measure actual tick label height + small gap
-    let tick-h = if x-tick-height != none { x-tick-height } else {
+    let tick-h = if x-tick-height != none { x-tick-height * 1.4 } else {
       measure(text(size: theme.axis-label-size)[0]).height * 1.4
     }
-    let x-title-dy = ax-origin-y + gap * 0.75 + tick-h
+    let x-title-dy = ax-origin-y + gap * .75 + tick-h
     place(left + top, dx: x-center - lbl-size.width / 2, dy: x-title-dy,
       lbl-content
     )

--- a/src/primitives/container.typ
+++ b/src/primitives/container.typ
@@ -9,7 +9,7 @@
 
 // Wraps chart body in a box with optional background/border and title.
 // Adds inset padding so light and dark themes render at the same outer size.
-#let chart-container(width, height, title, theme, extra-height: 0pt, legend: none, legend-width: 120pt, subtitle: none, radius: 0pt, body) = {
+#let chart-container(width, height, title, theme, extra-height: 0pt, legend: none, legend-width: 120pt, extra-legend-separation: 0pt, subtitle: none, radius: 0pt, body) = {
   let has-bg = theme.background != none
   let pad = theme.at("container-inset", default: container-inset)
   let has-subtitle = subtitle != none
@@ -29,6 +29,7 @@
     #draw-title(title, theme, subtitle: subtitle)
     #if lp == "top" and legend != none {
       legend
+      v(extra-legend-separation)
     }
     #if lp == "right" and legend != none {
       context {
@@ -40,7 +41,7 @@
         let base-dy = if legend-dy < 0pt { -legend-dy } else { 0pt }
         box(width: width + legend-gap + legend-width, height: content-h)[
           #place(left + top, dy: base-dy, box(width: width, height: height, body))
-          #place(left + top, dx: width + legend-gap, dy: base-dy + legend-dy,
+          #place(left + top, dx: width + legend-gap + extra-legend-separation, dy: base-dy + legend-dy,
             box(width: legend-width, legend))
         ]
       }
@@ -50,8 +51,8 @@
         let legend-dy = (height - legend-h) / 2
         let content-h = calc.max(height, legend-h)
         let base-dy = if legend-dy < 0pt { -legend-dy } else { 0pt }
-        box(width: width + legend-gap + legend-width, height: content-h)[
-          #place(left + top, dy: base-dy + legend-dy,
+        box(width: width + legend-gap + legend-width, height: content-h,)[
+          #place(left + top, dy: base-dy + legend-dy, dx: -extra-legend-separation,
             box(width: legend-width, legend))
           #place(left + top, dx: legend-width + legend-gap, dy: base-dy,
             box(width: width, height: height, body))
@@ -60,6 +61,7 @@
     } else {
       body
       if legend != none and lp == "bottom" {
+        v(extra-legend-separation)
         legend
       }
     }

--- a/src/theme.typ
+++ b/src/theme.typ
@@ -97,6 +97,7 @@
     background: none,
     border: none,
     border-radius: base-gap,
+    rotated-threshold: 8,  // number of x-axis labels before auto-rotating to save space
   )
 }
 


### PR DESCRIPTION
The option to add extra legend separation is due to the fact that the space taken up by rotated labels is not taken into account when placing the label since it is not precomputed, so an option to manually add label separtion is convenient. It can also be good for individual customization of labels.

Apart from that, y-labels are finally aligned perfectly to the center of their tick without em adjustements, and as mentioned the space taken up by rotated x-labels when it comes to placing the x axis title is taken into account, and rotated labels are aligned decently now.