### PR TITLE
Add line interpolation options and smooth radius for line charts

### DIFF
--- a/src/charts/line.typ
+++ b/src/charts/line.typ
@@ -1,12 +1,79 @@
 // line.typ - Line charts (single and multi-series)
 #import "../theme.typ": _resolve-ctx, get-color
 #import "../util.typ": normalize-data, nonzero, nice-ticks, normalize-errors
-#import "../validate.typ": validate-simple-data, validate-series-data
+#import "../validate.typ": validate-simple-data, validate-series-data, validate-line-style
 #import "../primitives/container.typ": chart-container
 #import "../primitives/axes.typ": cartesian-layout, draw-axis-lines, draw-grid, draw-axis-titles, draw-y-ticks, draw-x-category-labels, draw-x-even-labels, measure-y-tick-width, measure-x-tick-height
 #import "../primitives/legend.typ": draw-legend-auto
 #import "../primitives/annotations.typ": draw-annotations
 #import "../primitives/layout.typ": resolve-size
+
+#let _smooth-points(points, smooth-radius) = {
+  let smoothed = ()
+  for i in array.range(points.len()) {
+    let pt = points.at(i)
+    let lo = calc.max(i - smooth-radius, 0)
+    let hi = calc.min(i + smooth-radius, points.len() - 1)
+    let total-y = 0pt
+    let count = 0
+    for j in array.range(lo, hi + 1) {
+      total-y += points.at(j).at(1)
+      count += 1
+    }
+    smoothed.push((pt.at(0), total-y / count))
+  }
+  smoothed
+}
+
+#let _line-curve-components(points, line-interpolation) = {
+  let comps = (curve.move(points.first()),)
+  for i in array.range(points.len() - 1) {
+    let p1 = points.at(i)
+    let p2 = points.at(i + 1)
+    if line-interpolation == "smooth" {
+      let mid-x = (p1.at(0) + p2.at(0)) / 2
+      comps.push(curve.cubic((mid-x, p1.at(1)), (mid-x, p2.at(1)), p2))
+    } else if line-interpolation == "catmull-rom" {
+      let p0 = points.at(calc.max(i - 1, 0))
+      let p3 = points.at(calc.min(i + 2, points.len() - 1))
+      let c1 = (p1.at(0) + (p2.at(0) - p0.at(0)) / 6, p1.at(1) + (p2.at(1) - p0.at(1)) / 6)
+      let c2 = (p2.at(0) - (p3.at(0) - p1.at(0)) / 6, p2.at(1) - (p3.at(1) - p1.at(1)) / 6)
+      comps.push(curve.cubic(c1, c2, p2))
+    }
+  }
+  comps
+}
+
+#let draw-line-series(points, stroke, line-interpolation, smooth-radius) = {
+  if points.len() <= 1 {
+    return
+  }
+
+  if line-interpolation == "linear" {
+    for i in array.range(points.len() - 1) {
+      let p1 = points.at(i)
+      let p2 = points.at(i + 1)
+      place(
+        left + top,
+        line(
+          start: (p1.at(0), p1.at(1)),
+          end: (p2.at(0), p2.at(1)),
+          stroke: stroke,
+        )
+      )
+    }
+  } else {
+    let curve-points = if line-interpolation == "smooth" {
+      _smooth-points(points, smooth-radius)
+    } else {
+      points
+    }
+    place(
+      left + top,
+      curve(stroke: stroke, fill: none, .._line-curve-components(curve-points, line-interpolation))
+    )
+  }
+}
 
 /// Renders a single-series line chart.
 ///
@@ -17,6 +84,8 @@
 /// - show-points (bool): Draw data point markers
 /// - show-values (bool): Display value labels at data points
 /// - line-width (length): Stroke width of the line
+/// - line-interpolation (str): "linear", "smooth", or "catmull-rom"
+/// - smooth-radius (int): Moving average radius for smooth lines, 1 to 5
 /// - point-size (length): Diameter of point markers
 /// - fill-area (bool): Fill the area under the line
 /// - x-label (none, content): X-axis title
@@ -33,6 +102,8 @@
   show-points: true,
   show-values: false,
   line-width: 1.5pt,
+  line-interpolation: "linear",
+  smooth-radius: 1,
   point-size: 4pt,
   fill-area: false,
   x-label: none,
@@ -50,6 +121,7 @@
 ) = context {
   layout(size => {
   validate-simple-data(data, "line-chart")
+  validate-line-style(line-interpolation, smooth-radius, "line-chart")
   let t = _resolve-ctx(theme)
   let norm = normalize-data(data)
   let labels = norm.labels
@@ -97,19 +169,8 @@
         points.push((x, y))
       }
 
-      // Draw lines between points
-      #for i in array.range(calc.max(n - 1, 0)) {
-        let p1 = points.at(i)
-        let p2 = points.at(i + 1)
-        place(
-          left + top,
-          line(
-            start: (p1.at(0), p1.at(1)),
-            end: (p2.at(0), p2.at(1)),
-            stroke: line-width + get-color(t, 0),
-          )
-        )
-      }
+      // Draw line between points
+      #draw-line-series(points, line-width + get-color(t, 0), line-interpolation, smooth-radius)
 
       // Error bars (drawn under points so the marker sits on top)
       #if errs != none {
@@ -177,6 +238,8 @@
 /// - title (none, content): Optional chart title
 /// - show-points (bool): Draw data point markers
 /// - show-legend (bool): Show series legend
+/// - line-interpolation (str): "linear", "smooth", or "catmull-rom"
+/// - smooth-radius (int): Moving average radius for smooth lines, 1 to 5
 /// - x-label (none, content): X-axis title
 /// - y-label (none, content): Y-axis title
 /// - theme (none, dictionary): Theme overrides
@@ -190,6 +253,8 @@
   show-points: true,
   show-legend: true,
   line-width: 1.5pt,
+  line-interpolation: "linear",
+  smooth-radius: 1,
   point-size: 3pt,
   x-label: none,
   y-label: none,
@@ -199,6 +264,7 @@
 ) = context {
   layout(size => {
   validate-series-data(data, "multi-line-chart")
+  validate-line-style(line-interpolation, smooth-radius, "multi-line-chart")
   let t = _resolve-ctx(theme)
   let (width, height) = resolve-size(width, height, size, n: data.labels.len(), theme: t)
   let labels = data.labels
@@ -243,18 +309,7 @@
           points.push((x, y))
         }
 
-        for i in array.range(calc.max(n - 1, 0)) {
-          let p1 = points.at(i)
-          let p2 = points.at(i + 1)
-          place(
-            left + top,
-            line(
-              start: (p1.at(0), p1.at(1)),
-              end: (p2.at(0), p2.at(1)),
-              stroke: line-width + color,
-            )
-          )
-        }
+        draw-line-series(points, line-width + color, line-interpolation, smooth-radius)
 
         if show-points {
           for pt in points {

--- a/src/validate.typ
+++ b/src/validate.typ
@@ -404,3 +404,14 @@
       message: chart-name + ": tasks[" + str(i) + "] start (" + str(task.start) + ") must be less than end (" + str(task.end) + ")")
   }
 }
+
+#let validate-line-style(line-interpolation, smooth-radius, chart-name) = {
+  assert(
+    line-interpolation in ("linear", "smooth", "catmull-rom"),
+    message: chart-name + ": line-interpolation must be 'linear', 'smooth', or 'catmull-rom'"
+  )
+  assert(
+    type(smooth-radius) == int and smooth-radius >= 1 and smooth-radius <= 5,
+    message: chart-name + ": smooth-radius must be an integer from 1 to 5"
+  )
+}

--- a/tests/data.typ
+++ b/tests/data.typ
@@ -1,12 +1,15 @@
 // data.typ — Shared test data for all test modules
 
-#let simple-data = (labels: ("A", "B", "C"), values: (10, 20, 15))
+#let simple-data = (
+  labels: ("Q1", "Q2", "Q3", "Q4", "Q5"),
+  values: (12, 26, 15, 34, 22),
+)
 
 #let multi-data = (
-  labels: ("A", "B"),
+  labels: ("Q1", "Q2", "Q3", "Q4", "Q5"),
   series: (
-    (name: "X", values: (10, 20)),
-    (name: "Y", values: (15, 25)),
+    (name: "North", values: (12, 26, 15, 34, 22)),
+    (name: "South", values: (20, 14, 28, 18, 31)),
   ),
 )
 

--- a/tests/test-line.typ
+++ b/tests/test-line.typ
@@ -9,7 +9,15 @@
 
 #line-chart(simple-data, title: "line-chart")
 
+#line-chart(simple-data, title: "line-chart smooth", line-interpolation: "smooth")
+
+#line-chart(simple-data, title: "line-chart catmull-rom", line-interpolation: "catmull-rom")
+
 #multi-line-chart(multi-data, title: "multi-line-chart")
+
+#multi-line-chart(multi-data, title: "multi-line-chart smooth", line-interpolation: "smooth")
+
+#multi-line-chart(multi-data, title: "multi-line-chart catmull-rom", line-interpolation: "catmull-rom")
 
 #let dual-data = (
   labels: ("Q1", "Q2", "Q3", "Q4"),


### PR DESCRIPTION
Introduce line interpolation options ("linear", "smooth", "catmull-rom") and a smooth radius parameter for line charts. These enhancements improve the visual representation of data by allowing for smoother transitions between points. Validation for the new parameters has been added to ensure correct usage. Test cases have been updated to demonstrate the new features.

<img width="204" height="442" alt="image" src="https://github.com/user-attachments/assets/e2f02b51-5e9d-4c89-a35a-7f5c11719612" />


<img width="204" height="442" alt="image" src="https://github.com/user-attachments/assets/77516ee5-efa4-4b7f-8534-84c6446b848f" />
