### PR TITLE
Implement three parameters that were accepted but ignored

### DIFF
--- a/src/charts/line.typ
+++ b/src/charts/line.typ
@@ -62,6 +62,31 @@
   )
 }
 
+// Fills the region between the line and `baseline-y`, following the same
+// interpolation as the drawn line so fill and stroke share an edge.
+#let draw-line-fill(points, fill, baseline-y, line-interpolation, smooth-radius) = {
+  if points.len() <= 1 {
+    return
+  }
+
+  let curve-points = if line-interpolation == "smooth" {
+    _smooth-points(points, smooth-radius)
+  } else {
+    points
+  }
+  place(
+    left + top,
+    curve(
+      stroke: none,
+      fill: fill,
+      .._line-curve-components(curve-points, line-interpolation),
+      curve.line((curve-points.last().at(0), baseline-y)),
+      curve.line((curve-points.first().at(0), baseline-y)),
+      curve.close(mode: "straight"),
+    )
+  )
+}
+
 /// Renders a single-series line chart.
 ///
 /// - data (dictionary, array): Label-value pairs as dict or array of tuples
@@ -75,6 +100,7 @@
 /// - smooth-radius (int): Moving average radius for smooth lines, 1 to 5
 /// - point-size (length): Diameter of point markers
 /// - fill-area (bool): Fill the area under the line
+/// - fill-opacity (ratio): Opacity of the filled area
 /// - x-label (none, content): X-axis title
 /// - y-label (none, content): Y-axis title
 /// - annotations (none, array): Optional annotation descriptors
@@ -93,6 +119,7 @@
   smooth-radius: 1,
   point-size: 4pt,
   fill-area: false,
+  fill-opacity: 40%,
   x-label: none,
   y-label: none,
   errors: none,
@@ -154,6 +181,20 @@
         let x = if n == 1 { origin-x + chart-width / 2 } else { origin-x + (i / (n - 1)) * chart-width }
         let y = pad-top + chart-height - ((val - min-val) / val-range) * chart-height
         points.push((x, y))
+      }
+
+      // Area fill under the line — baseline at zero, or the axis floor when the
+      // visible range excludes it, so the fill never escapes the plot area
+      #if fill-area {
+        let zero-y = pad-top + chart-height - ((0 - min-val) / val-range) * chart-height
+        let baseline-y = calc.max(pad-top, calc.min(pad-top + chart-height, zero-y))
+        draw-line-fill(
+          points,
+          get-color(t, 0).transparentize(100% - fill-opacity),
+          baseline-y,
+          line-interpolation,
+          smooth-radius,
+        )
       }
 
       // Draw line between points

--- a/src/charts/scatter.typ
+++ b/src/charts/scatter.typ
@@ -539,6 +539,11 @@
         }
       }
 
+      // Axis titles
+      #let y-tw = measure-y-tick-width(y-min, y-max, t)
+      #let x-th = measure-x-tick-height(([#x-max],), t)
+      #draw-axis-titles(x-label, y-label, origin-x + chart-width / 2, pad-top + chart-height / 2, t, origin-x: origin-x, origin-y: origin-y, y-tick-width: y-tw, x-tick-height: x-th)
+
       #draw-annotations(annotations, origin-x, pad-top, chart-width, chart-height, x-min, x-max, y-min, y-max, t)
     ]
 

--- a/tests/test-options.typ
+++ b/tests/test-options.typ
@@ -14,6 +14,12 @@
 == Line chart options
 #line-chart(simple-data, width: 250pt, height: 150pt, show-points: false, fill-area: true, title: "fill, no points")
 #line-chart(simple-data, width: 250pt, height: 150pt, show-points: true, show-values: true, title: "points + values")
+#line-chart(simple-data, width: 250pt, height: 150pt, fill-area: true, fill-opacity: 80%, title: "fill, custom opacity")
+#line-chart(simple-data, width: 250pt, height: 150pt, fill-area: true, line-interpolation: "catmull-rom", title: "fill follows the curve")
+#line-chart(
+  (labels: ("A", "B", "C", "D"), values: (20, -15, 30, -5)),
+  width: 250pt, height: 150pt, fill-area: true, title: "fill across zero",
+)
 
 == Histogram options
 #histogram(

--- a/tests/test-scatter.typ
+++ b/tests/test-scatter.typ
@@ -14,3 +14,10 @@
 #bubble-chart(bubble-data, title: "bubble-chart")
 
 #multi-bubble-chart(multi-bubble-data, title: "multi-bubble-chart")
+
+#multi-bubble-chart(
+  multi-bubble-data,
+  width: 350pt, height: 220pt,
+  title: "multi-bubble-chart with axis titles",
+  x-label: "Quarter", y-label: "Revenue", size-label: "Headcount",
+)


### PR DESCRIPTION
## Summary

Audited every function signature in `src/` against its body, looking for parameters that callers can pass with no effect and no error. Three turned up — all documented, so the docs promised behavior the code never delivered.

| Function | Parameter | Was |
|---|---|---|
| `line-chart` | `fill-area` | Documented, and passed by `tests/test-options.typ`, but never read |
| `multi-bubble-chart` | `x-label` | Documented, wired up in all three sibling scatter functions, dropped here |
| `multi-bubble-chart` | `y-label` | Same |

## Changes

**`line-chart` `fill-area`** now fills between the line and the zero baseline. The fill is built from the same curve components as the stroke, so it follows `smooth` and `catmull-rom` interpolation rather than cutting a straight chord under a curved line. When the visible y-range excludes zero, the baseline clamps to the plot floor so the fill can't escape the chart area. Adds `fill-opacity` (default `40%`, matching `area-chart`).

**`multi-bubble-chart` `x-label` / `y-label`** render through `draw-axis-titles`, matching `scatter-plot`, `multi-scatter-plot`, and `bubble-chart`.

## Notes

Both are additive — no existing call changes behavior unless it was already passing one of these parameters and silently getting nothing.

New tests cover fill across a zero crossing, custom opacity, curved interpolation, and bubble axis titles. Full suite, both examples, and all 21 per-chart demos compile with zero warnings.

The same audit also found ~60 parameters that exist and work but have no `///` doc line (`annotations` and `subtitle` are the most common). That's a separate docs sweep, not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)