### PR TITLE
Document all 58 undocumented parameters, fix shadowed pie-chart radius

### DIFF
--- a/src/charts/area.typ
+++ b/src/charts/area.typ
@@ -22,6 +22,9 @@
 /// - point-size (length): Radius of point markers
 /// - x-label (none, content): X-axis title
 /// - y-label (none, content): Y-axis title
+/// - annotations (none, array): Optional annotation descriptors
+/// - show-ticks (bool): Draw tick marks on the axis lines
+/// - show-minor-grid (bool): Draw lighter minor grid lines between the major ones
 /// - theme (none, dictionary): Theme overrides
 /// - extra-legend-separation (length): Extra space between legend and chart
 /// -> content
@@ -151,6 +154,7 @@
 /// - show-legend (bool): Show series legend
 /// - x-label (none, content): X-axis title
 /// - y-label (none, content): Y-axis title
+/// - annotations (none, array): Optional annotation descriptors
 /// - theme (none, dictionary): Theme overrides
 /// - extra-legend-separation (length): Extra space between legend and chart
 /// -> content

--- a/src/charts/bar.typ
+++ b/src/charts/bar.typ
@@ -19,6 +19,7 @@
 /// - show-values (bool): Display value labels beside bars
 /// - x-label (none, content): X-axis title
 /// - y-label (none, content): Y-axis title
+/// - annotations (none, array): Optional annotation descriptors
 /// - theme (none, dictionary): Theme overrides
 /// - extra-legend-separation (length): Extra space between legend and chart
 /// -> content
@@ -124,6 +125,13 @@
 /// - x-label (none, content): X-axis title
 /// - y-label (none, content): Y-axis title
 /// - annotations (none, array): Optional annotation descriptors
+/// - errors (none, array): Symmetric `(e1, e2, ...)` or asymmetric `((lo1, hi1), ...)`
+/// - error-color (auto, color): Error bar color; `auto` uses the theme text color
+/// - error-cap-width (auto, length): Width of the error bar caps; `auto` scales with bar width
+/// - show-ticks (bool): Draw tick marks on the axis lines
+/// - show-minor-grid (bool): Draw lighter minor grid lines between the major ones
+/// - subtitle (none, content): Optional subtitle below the title
+/// - radius (length): Corner radius of the chart container
 /// - theme (none, dictionary): Theme overrides
 /// - extra-legend-separation (length): Extra space between legend and chart
 /// -> content
@@ -263,6 +271,7 @@
 /// - show-legend (bool): Show series legend
 /// - x-label (none, content): X-axis title
 /// - y-label (none, content): Y-axis title
+/// - annotations (none, array): Optional annotation descriptors
 /// - theme (none, dictionary): Theme overrides
 /// - extra-legend-separation (length): Extra space between legend and chart
 /// -> content
@@ -359,6 +368,7 @@
 /// - show-legend (bool): Show series legend
 /// - x-label (none, content): X-axis title
 /// - y-label (none, content): Y-axis title
+/// - annotations (none, array): Optional annotation descriptors
 /// - theme (none, dictionary): Theme overrides
 /// - extra-legend-separation (length): Extra space between legend and chart
 /// -> content

--- a/src/charts/diverging.typ
+++ b/src/charts/diverging.typ
@@ -22,6 +22,7 @@
 /// - title (none, content): Optional chart title
 /// - show-values (bool): Display value labels at bar ends
 /// - bar-height (auto, float): Bar thickness as fraction of slot (0 to 1), auto = 0.6
+/// - x-label (none, content): X-axis title
 /// - theme (none, dictionary): Theme overrides
 /// - extra-legend-separation (length): Extra space between legend and chart
 /// -> content

--- a/src/charts/gantt.typ
+++ b/src/charts/gantt.typ
@@ -19,6 +19,8 @@
 /// - bar-height (length): Height of each task bar
 /// - gap (length): Vertical gap between task bars
 /// - show-grid (bool): Whether to draw vertical grid lines
+/// - x-label (none, content): X-axis title
+/// - show-legend (bool): Show a legend of task group names and colors
 /// - today (none, int): Optional time index to draw a "today" marker line
 /// - theme (none, dictionary): Theme overrides
 /// - extra-legend-separation (length): Extra space between legend and chart

--- a/src/charts/heatmap.typ
+++ b/src/charts/heatmap.typ
@@ -15,6 +15,8 @@
 /// - palette (str, array): Color palette name or array of color stops. Append `"-r"` to reverse named palettes.
 /// - show-legend (bool): Show color scale legend
 /// - reverse (bool): Reverse palette direction
+/// - subtitle (none, content): Optional subtitle below the title
+/// - radius (length): Corner radius of the chart container
 /// - theme (none, dictionary): Theme overrides
 /// -> content
 #let heatmap(

--- a/src/charts/histogram.typ
+++ b/src/charts/histogram.typ
@@ -21,6 +21,9 @@
 /// - density (bool): Normalize to probability density instead of counts
 /// - x-label (none, content): X-axis title
 /// - y-label (none, content): Y-axis title
+/// - annotations (none, array): Optional annotation descriptors
+/// - show-ticks (bool): Draw tick marks on the axis lines
+/// - show-minor-grid (bool): Draw lighter minor grid lines between the major ones
 /// - theme (none, dictionary): Theme overrides
 /// -> content
 #let histogram(

--- a/src/charts/line.typ
+++ b/src/charts/line.typ
@@ -103,7 +103,14 @@
 /// - fill-opacity (ratio): Opacity of the filled area
 /// - x-label (none, content): X-axis title
 /// - y-label (none, content): Y-axis title
+/// - errors (none, array): Symmetric `(e1, e2, ...)` or asymmetric `((lo1, hi1), ...)`
+/// - error-color (auto, color): Error bar color; `auto` uses the series color
+/// - error-cap-width (length): Width of the error bar caps
 /// - annotations (none, array): Optional annotation descriptors
+/// - show-ticks (bool): Draw tick marks on the axis lines
+/// - show-minor-grid (bool): Draw lighter minor grid lines between the major ones
+/// - subtitle (none, content): Optional subtitle below the title
+/// - radius (length): Corner radius of the chart container
 /// - theme (none, dictionary): Theme overrides
 /// - extra-legend-separation (length): Extra space between legend and chart
 /// -> content
@@ -268,8 +275,11 @@
 /// - show-legend (bool): Show series legend
 /// - line-interpolation (str): "linear", "smooth", or "catmull-rom"
 /// - smooth-radius (int): Moving average radius for smooth lines, 1 to 5
+/// - line-width (length): Stroke width of each series line
+/// - point-size (length): Radius of point markers
 /// - x-label (none, content): X-axis title
 /// - y-label (none, content): Y-axis title
+/// - annotations (none, array): Optional annotation descriptors
 /// - theme (none, dictionary): Theme overrides
 /// - extra-legend-separation (length): Extra space between legend and chart
 /// -> content

--- a/src/charts/lollipop.typ
+++ b/src/charts/lollipop.typ
@@ -141,6 +141,7 @@
 /// - show-values (bool): Display value labels beside dots
 /// - x-label (none, content): X-axis title
 /// - y-label (none, content): Y-axis title
+/// - annotations (none, array): Optional annotation descriptors
 /// - theme (none, dictionary): Theme overrides
 /// -> content
 #let horizontal-lollipop-chart(

--- a/src/charts/pie.typ
+++ b/src/charts/pie.typ
@@ -16,6 +16,8 @@
 /// - show-percentages (bool): Display percentage labels on slices
 /// - donut (bool): Cut out the center to create a donut chart
 /// - donut-ratio (float): Inner radius as fraction of outer radius (0 to 1)
+/// - subtitle (none, content): Optional subtitle below the title
+/// - radius (length): Corner radius of the chart container
 /// - theme (none, dictionary): Theme overrides
 /// -> content
 #let pie-chart(
@@ -67,7 +69,7 @@
     total-width = budget
   }
 
-  let radius = size / 2
+  let pie-radius = size / 2
 
   // Build legend content
   let legend-entries = if show-legend {
@@ -96,14 +98,14 @@
   align(center, chart-container(size, size, title, t-with-legend, extra-height: extra-height, legend: if show-legend { legend-content }, legend-width: legend-width, subtitle: subtitle, radius: radius)[
     // Pie chart
     #box(width: size, height: size)[
-      #let center-x = radius
-      #let center-y = radius
+      #let center-x = pie-radius
+      #let center-y = pie-radius
       #let current-deg = 0
 
       #for (i, val) in values.enumerate() {
         let slice-deg = (val / total) * 360
 
-        let pts = pie-slice-points(center-x, center-y, radius, current-deg, current-deg + slice-deg)
+        let pts = pie-slice-points(center-x, center-y, pie-radius, current-deg, current-deg + slice-deg)
 
         place(
           left + top,
@@ -121,9 +123,9 @@
           let pct-text = str(pct) + "%"
           let pct-len = pct-text.len()
           // Approximate available width from arc at label distance
-          let label-dist = radius * (if donut { 0.75 } else { 0.7 })
+          let label-dist = pie-radius * (if donut { 0.75 } else { 0.7 })
           let arc-w = (label-dist / 1pt) * slice-deg / 360 * 2 * calc.pi * 1pt
-          let arc-h = radius * 0.3  // radial height available
+          let arc-h = pie-radius * 0.3  // radial height available
           let fit = try-fit-label(arc-w, arc-h, t.value-label-size, pct-len, shrink-min: 5pt)
           if fit.fits {
             let lx = center-x + label-dist * calc.cos(mid-deg * 1deg)
@@ -143,7 +145,7 @@
 
       // Donut hole
       #if donut {
-        place-donut-hole(center-x, center-y, radius * donut-ratio, t)
+        place-donut-hole(center-x, center-y, pie-radius * donut-ratio, t)
       }
     ]
   ])

--- a/src/charts/radar.typ
+++ b/src/charts/radar.typ
@@ -9,7 +9,7 @@
 ///
 /// - data (dictionary): Dict with `labels` (axis names) and `series` (each with `name` and `values`)
 /// - size (length): Diameter of the radar chart
-// - axis-max-value (none, number): The maximum value of the chart’s axes
+/// - axis-max-value (none, number): Fixed maximum for every axis; `none` uses the largest data value
 /// - title (none, content): Optional chart title
 /// - show-legend (bool): Show series legend
 /// - show-value-labels (bool): Display scale values and data point labels

--- a/src/charts/rings.typ
+++ b/src/charts/rings.typ
@@ -7,6 +7,16 @@
 /// Concentric ring progress chart (fitness rings).
 /// Outermost ring = first entry, innermost = last.
 /// Rings that exceed 100 % wrap around (overlap).
+///
+/// - entries (array): Array of dicts with `name`, `value`, and `max`
+/// - size (length): Outer diameter of the ring stack
+/// - title (none, content): Optional chart title
+/// - ring-width (length): Stroke thickness of each ring
+/// - gap (length): Gap between concentric rings
+/// - show-labels (bool): Display entry names beside the rings
+/// - show-values (bool): Display each entry's value and max
+/// - theme (none, dictionary): Theme overrides
+/// -> content
 #let ring-progress(
   entries,          // Array of dicts: ((name: "Move", value: 75, max: 100), ...)
   size: 150pt,

--- a/src/charts/scatter.typ
+++ b/src/charts/scatter.typ
@@ -20,6 +20,10 @@
 /// - show-grid (auto, bool): Draw background grid lines; `auto` uses theme default
 /// - color (none, color): Override point color
 /// - annotations (none, array): Optional annotation descriptors
+/// - show-ticks (bool): Draw tick marks on the axis lines
+/// - show-minor-grid (bool): Draw lighter minor grid lines between the major ones
+/// - subtitle (none, content): Optional subtitle below the title
+/// - radius (length): Corner radius of the chart container
 /// - theme (none, dictionary): Theme overrides
 /// -> content
 #let scatter-plot(
@@ -122,6 +126,7 @@
 /// - point-size (length): Diameter of point markers
 /// - show-grid (auto, bool): Draw background grid lines; `auto` uses theme default
 /// - show-legend (bool): Show series legend
+/// - annotations (none, array): Optional annotation descriptors
 /// - theme (none, dictionary): Theme overrides
 /// - extra-legend-separation (length): Extra space between legend and chart
 /// -> content
@@ -227,6 +232,8 @@
 /// - color (none, color): Override bubble color
 /// - show-labels (bool): Display text labels on bubbles
 /// - labels (none, array): Array of label strings for each bubble
+/// - size-label (none, content): Title for the bubble size legend; `none` hides the legend
+/// - annotations (none, array): Optional annotation descriptors
 /// - theme (none, dictionary): Theme overrides
 /// -> content
 #let bubble-chart(
@@ -446,6 +453,8 @@
 /// - max-radius (length): Maximum bubble radius
 /// - show-grid (auto, bool): Draw background grid lines; `auto` uses theme default
 /// - show-legend (bool): Show series legend
+/// - size-label (none, content): Title for the bubble size legend; `none` hides the legend
+/// - annotations (none, array): Optional annotation descriptors
 /// - theme (none, dictionary): Theme overrides
 /// -> content
 #let multi-bubble-chart(

--- a/src/charts/violin.typ
+++ b/src/charts/violin.typ
@@ -25,6 +25,7 @@
 /// - stroke-width (length): Stroke width for violin outlines and inner box elements
 /// - x-label (none, content): X-axis title
 /// - y-label (none, content): Y-axis title
+/// - annotations (none, array): Optional annotation descriptors
 /// - theme (none, dictionary): Theme overrides
 /// -> content
 #let violin-plot(

--- a/src/charts/waterfall.typ
+++ b/src/charts/waterfall.typ
@@ -22,6 +22,8 @@
 /// - total-color (none, color): Override color for total bars
 /// - x-label (none, content): X-axis title
 /// - y-label (none, content): Y-axis title
+/// - annotations (none, array): Optional annotation descriptors
+/// - show-legend (bool): Show a legend of the positive, negative, and total bar colors
 /// - theme (none, dictionary): Theme overrides
 /// - extra-legend-separation (length): Extra space between legend and chart
 /// -> content

--- a/tests/test-pie.typ
+++ b/tests/test-pie.typ
@@ -10,3 +10,6 @@
 #pie-chart(simple-data, title: "pie-chart")
 
 #pie-chart(simple-data, title: "pie-chart (donut)", donut: true)
+
+// `radius` is the container corner radius, not the pie geometry
+#pie-chart(simple-data, title: "pie-chart (container radius)", radius: 8pt, theme: themes.dark)


### PR DESCRIPTION
## Summary

Every public function's `///` block now covers its full signature — 58 parameters across 20 functions were previously undocumented, so they never appeared on the Universe docs page despite working fine.

The audit that found them also turned up two real bugs hiding behind the gaps.

## Bugs found

**`radar.typ` used `//` instead of `///`** for `axis-max-value`. A non-doc comment terminates the docstring, so `data` and `size` — both correctly written *above* that line — were silently dropped from the generated docs as well. One character; three parameters restored.

**`pie-chart`'s `radius` was shadowed.** The parameter was declared at line 32, then overwritten at line 72 by `let radius = size / 2` — the pie's own geometric radius. Two consequences:

- Callers passing `radius:` got no effect at all
- The container received `size / 2` as its corner radius, so every pie with a visible background or border was rounded by half the chart size rather than the requested amount

Before and after, `radius: 0pt` vs `radius: 4pt` on a dark theme:

| Before | After |
|---|---|
| Both pies identically rounded by ~65pt | `0pt` square, `4pt` subtly rounded — matching `bar-chart` |

The local is renamed to `pie-radius`. **This is a visible change** for existing pie charts on themes with a background or border: they now have square corners by default, consistent with every other chart type. Pass `radius:` to round them.

A follow-up audit for the same shadowing pattern across all of `src/` found no other cases.

## Documentation added

Mostly options that worked but were invisible: `annotations` (10 functions), `subtitle`, `radius`, `show-ticks`, `show-minor-grid`, plus `errors` / `error-color` / `error-cap-width` on `bar-chart` and `line-chart`, `size-label` on both bubble charts, `x-label` on `diverging-bar-chart` and `gantt-chart`, `show-legend` on `gantt-chart` and `waterfall-chart`, `line-width` / `point-size` on `multi-line-chart`, and the entire `ring-progress` signature, which had no parameter docs at all.

## Verification

Both audit directions now report zero: no parameter is undocumented, and no doc line refers to a parameter that doesn't exist. Full test suite, both examples, and all 21 per-chart demos compile with zero warnings — including against Typst 0.13.0, the declared compiler floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)